### PR TITLE
remove extra line after class declaration

### DIFF
--- a/polytech/raquem.py
+++ b/polytech/raquem.py
@@ -11,7 +11,6 @@ POEM_SPEECH_RATE = 130
 BACK_COMMAND = "back"
 
 class Pet:
-    
     SPECIES_DICT = {
         "Dog": "🐶",
         "Cat": "🐱",


### PR DESCRIPTION
This update removes the extra blank lines between the class declaration and the first set of logic/code blocks (e.g., method definitions or properties). Keeping code closely grouped improves readability and follows standard style conventions.