### PR TITLE
remove space

### DIFF
--- a/polytech/victorio.py
+++ b/polytech/victorio.py
@@ -4,7 +4,7 @@ from colorama import init, Fore
 EXIT_OPTION = 0
 LINE_WIDTH = 55
 
-init(autoreset = True)
+init(autoreset=True)
 
 class WellnessDiary:
     def __init__(self):


### PR DESCRIPTION
cleaned up the init() call by removing the space before the equals sign for better code style consistency from
init(autoreset = True) to init(autoreset=True)